### PR TITLE
Update xcbeautify to 0.7.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/thii/xcbeautify.git",
         "state": {
           "branch": null,
-          "revision": "8cffdcedfa9776f8d9ad45ea55e547f51316f3d5",
-          "version": "0.5.0"
+          "revision": "918fa0d16f45477a01f1806a5f6f7fa7ab3ad328",
+          "version": "0.7.0"
         }
       }
     ]


### PR DESCRIPTION
This update includes several fixes for parsing Xcode 11.1 and above's
buid outputs.