### PR TITLE
Remove Slack message task from Roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,6 @@ workflow.run()
 
 - [ ] Auto detect schemes and build settings
 - [ ] Build for Android
-- [ ] Post to chat services like Slack
 - [ ] Interact with the new Appstore Connect API
 - [ ] Integrate with services like Firebase
 - [ ] Capture screenshots


### PR DESCRIPTION
Hi, 

It seems that Slack support is already integrated in `develop`, so I think it could be removed from Roadmap to keep it in sync with the current implementation. Right now it's a bit confusing.

P.S. Maybe it makes sense to have a list of links to the Github issues as a Roadmap? And an issue could contain more specifics of what is necessary to do. That way it's easier to join the project IMO. 