### PR TITLE
Add tests for Wait task

### DIFF
--- a/Sources/Core/Tasks/Wait/Wait.swift
+++ b/Sources/Core/Tasks/Wait/Wait.swift
@@ -24,7 +24,8 @@ extension Wait: Task {
             completion(.success(()))
         })
 
-        RunLoop.current.run()
+        
+        RunLoop.current.run(until: Date(timeIntervalSinceNow: seconds))
     }
 }
 

--- a/Tests/PumaTests/WaitTests.swift
+++ b/Tests/PumaTests/WaitTests.swift
@@ -1,0 +1,50 @@
+import Foundation
+import XCTest
+@testable import PumaCore
+
+final class WaitTests: XCTestCase {
+    private static let minTimeThreshold = 0.01
+    
+    func testZeroTimeout() {
+        let wait = Wait()
+        let workflow = Workflow()
+        
+        let expectation = self.expectation(description: "Expect zero timeout for completion call")
+        wait.run(workflow: workflow) { (result) in
+            guard result.isSuccessfull else {
+                XCTFail("Only successfull completion is expected")
+                return
+            }
+            
+            expectation.fulfill()
+        }
+        
+        self.wait(for: [expectation], timeout: WaitTests.minTimeThreshold)
+    }
+    
+    func testPositiveTimeout() {
+        let positiveTimeout = 0.2
+        
+        let workflow = Workflow()
+        let wait = Wait()
+        wait.wait(for: positiveTimeout)
+        
+        let expectation = self.expectation(description: "Expect specified timeout for completion call")
+        wait.run(workflow: workflow) { (result) in
+            guard result.isSuccessfull else {
+                XCTFail("Only successfull completion is expected")
+                return
+            }
+            
+            expectation.fulfill()
+        }
+        
+        self.wait(for: [expectation], timeout: positiveTimeout + WaitTests.minTimeThreshold)
+    }
+}
+
+private extension Result where Success == Void {
+    var isSuccessfull: Bool {
+        return (try? get()) != nil
+    }
+}


### PR DESCRIPTION
Hi,

**Description**

I've added unit tests for Wait task to ensure that completion is called for different parameters. Unfortunately, it was impossible to test the existing implementation, `Runloop.current.run()` was looping infinitely in test environment. So the `run()` changed to the `run(until: )` where it's limited as well to the provided timeout. However, I'm not sure how good is this solution. More details in *Concerns*

**Concerns**
- A general concern of the Timer + Runloop. I've changed the implementation to limit the time runloop will be executed, however it might introduce races between Timer and Runloop, e.g. Runloop might stop earlier before receiving input from Timer. The timer starts earlier so it has more time, but it's really tricky to predict how it would work.
- Maybe I don't completely get the idea of how Wait is supposed to work (or what environment is), but if the task must wait for some time, it's possible to just block execution of the current thread for specified time and call completion block. For example, by doing `NSCondition.wait(until:)`. What do you think?