### PR TITLE
Adapt GetDestinations to be unit tested

### DIFF
--- a/Sources/iOS/Library/Get/GetDestinations/GetDestinations.swift
+++ b/Sources/iOS/Library/Get/GetDestinations/GetDestinations.swift
@@ -8,11 +8,17 @@
 import PumaCore
 import Foundation
 
-public class GetDestinations {
-    public init() {}
+/// An abstraction over a bash script that executes and prints an output
+public protocol ConsoleCommand {
+    func execute(with: Workflow) -> String?
+}
 
-    public func getAvailable(workflow: Workflow) throws -> [Destination] {
-        let string = try CommandLine().runBash(
+/// Runs xcrun ang get list of available iOS simulators
+public struct GetListOfDevicesCommand: ConsoleCommand {
+    public init() {}
+    
+    public func execute(with workflow: Workflow) -> String? {
+        return try? CommandLine().runBash(
             workflow: workflow,
             program: "xcrun simctl",
             arguments: [
@@ -24,81 +30,105 @@ public class GetDestinations {
                 logger: workflow.logger, filter: { $0.starts(with: "name=") }
             )
         )
+    }
+    
+}
 
-        guard let data = string.data(using: .utf8) else {
+public class GetDestinations {
+    private let consoleCommand: ConsoleCommand
+    
+    public init(consoleCommand: ConsoleCommand = GetListOfDevicesCommand()) {
+        self.consoleCommand = consoleCommand
+    }
+
+    public func getAvailable(workflow: Workflow) throws -> [Destination] {
+        guard let consoleOutput = consoleCommand.execute(with: workflow) else {
             throw PumaError.invalid
         }
+        
+        guard let devices = parse(output: consoleOutput) else {
+            throw PumaError.invalid // TODO: improve
+        }
 
-        let response: Response = try JSONDecoder().decode(Response.self, from: data)
-        let devicesWithOS: [DeviceWithOS] = response.devices.flatMap({ key, value in
-            return value.map({ DeviceWithOS(device: $0, os: key) })
-        })
-
-        let destinations: [Destination] = try devicesWithOS
-            .filter({ withOS in
-                return withOS.device.isAvailable
-            })
-            .compactMap({ withOS in
-                guard
-                    let platform = self.platform(withOS: withOS),
-                    let os = try self.os(withOS: withOS)
-                else {
-                    return  nil
-                }
-
+        let destinations: [Destination] = devices
+            .filter { $0.isAvailable }
+            .compactMap { device in
+                guard let os = device.supportedOS else { return nil }
+                guard let platform = device.supportedPlatform else { return nil }
+                
                 return Destination(
-                    name: withOS.device.name,
+                    name: device.name,
                     platform: platform,
                     os: os,
-                    udid: withOS.device.udid
+                    udid: device.udid
                 )
-            })
+            }
 
         return destinations
     }
 
     func findUdid(workflow: Workflow, destination: Destination) throws -> String? {
-        let availableDestinations = try self.getAvailable(workflow: workflow)
-        return availableDestinations.first(where: {
-            $0.name == destination.name && $0.platform == destination.platform && $0.os == destination.os
-        })?.udid
+        let available = try? getAvailable(workflow: workflow)
+        return available?.first { $0 == destination }?.udid
     }
+    
+    // MARK: Private
+    private func parse(output: String) -> [Device]? {
+        guard let data = output.data(using: .utf8) else {
+            return nil
+        }
 
-    // MARK: - Private
+        struct DevicesMapJSON: Decodable {
+            typealias OS = String
+            typealias DevicesMap = [OS : [Device]]
+            
+            let devices: DevicesMap
+        }
+        
+        let devicesMap = try? JSONDecoder().decode(DevicesMapJSON.self, from: data)
+        return devicesMap?.devices.flatMap { (arg) -> [Device] in
+            let (key, value) = arg
+            return value.map { Device(
+                state: $0.state,
+                name: $0.name,
+                udid: $0.udid,
+                isAvailable: $0.isAvailable,
+                os: key)
+            }
+        }
+    }
+}
 
-    private func platform(withOS: DeviceWithOS) -> String? {
-        let list: [String] = [
-            Destination.Platform.iOS,
-            Destination.Platform.watchOS,
-            Destination.Platform.macOS,
-            Destination.Platform.tvOS,
-        ]
+struct Device: Decodable {
+    let state: String
+    let name: String
+    let udid: String
+    let os: String
+    let isAvailable: Bool
+    
+    init(state: String, name: String, udid: String, isAvailable: Bool, os: String = "") {
+        self.state = state
+        self.name = name
+        self.udid = udid
+        self.os = os
+        self.isAvailable = isAvailable
+    }
+}
 
-        return list.first(where: { withOS.os.contains($0) })
+extension Device {
+    var supportedPlatform: Destination.Platform? {
+        guard let currentPlatform = Destination.Platform(rawValue: os) else { return nil }
+        guard Destination.Platform.allSupported.contains(currentPlatform) else { return nil }
+        
+        return currentPlatform
     }
 
     // com.apple.CoreSimulator.SimRuntime.iOS-13-2
-    private func os(withOS: DeviceWithOS) throws -> String? {
-        guard let string = try withOS.os.matches(pattern: #"(-\d+)+"#).first else {
+    var supportedOS: String? {
+        guard let string = try? os.matches(pattern: #"(-\d+)+"#).first else {
             return nil
         }
 
         return string.dropFirst().replacingOccurrences(of: "-", with: ".")
     }
-}
-
-private struct Response: Decodable {
-    let devices: [String: [Device]]
-}
-
-private struct Device: Decodable {
-    let state: String
-    let name: String
-    let udid: String
-    let isAvailable: Bool
-}
-
-private struct DeviceWithOS {
-    let device: Device
-    let os: String
 }

--- a/Sources/iOS/Library/Get/GetDestinations/GetDestinations.swift
+++ b/Sources/iOS/Library/Get/GetDestinations/GetDestinations.swift
@@ -8,16 +8,10 @@
 import PumaCore
 import Foundation
 
-/// An abstraction over a bash script that executes and prints an output
-public protocol ConsoleCommand {
-    func execute(with: Workflow) -> String?
-}
-
-/// Runs xcrun ang get list of available iOS simulators
-public struct GetListOfDevicesCommand: ConsoleCommand {
-    public init() {}
+/// Runs xcrun and gets list of available simulators
+public struct GetListOfDevicesCommand {
     
-    public func execute(with workflow: Workflow) -> String? {
+    public static func execute(with workflow: Workflow) -> String? {
         return try? CommandLine().runBash(
             workflow: workflow,
             program: "xcrun simctl",
@@ -35,14 +29,15 @@ public struct GetListOfDevicesCommand: ConsoleCommand {
 }
 
 public class GetDestinations {
-    private let consoleCommand: ConsoleCommand
+    public typealias BashCommand = (Workflow) -> String?
+    private let bashCommand: BashCommand
     
-    public init(consoleCommand: ConsoleCommand = GetListOfDevicesCommand()) {
-        self.consoleCommand = consoleCommand
+    public init(bashCommand: @escaping BashCommand = GetListOfDevicesCommand.execute) {
+        self.bashCommand = bashCommand
     }
 
     public func getAvailable(workflow: Workflow) throws -> [Destination] {
-        guard let consoleOutput = consoleCommand.execute(with: workflow) else {
+        guard let consoleOutput = bashCommand(workflow) else {
             throw PumaError.invalid
         }
         

--- a/Sources/iOS/Library/Tools/XcodeBuild/Destination.swift
+++ b/Sources/iOS/Library/Tools/XcodeBuild/Destination.swift
@@ -9,18 +9,27 @@ import Foundation
 
 public struct Destination: Equatable {
     public let name: String
-    public let platform: String
+    public let platform: Platform
     public let os: String
     public let udid: String?
 
-    public struct Platform {
-        public static let iOS = "iOS"
-        public static let iOSSimulator = "iOS Simulator"
-        public static let tvOS = "tvOS"
-        public static let tvOSSimulator = "tvOS Simulator"
-        public static let watchOS = "watchOS"
-        public static let watchOSSimulator = "watchOS Simulator"
-        public static let macOS = "OS X"
+    public enum Platform: String {
+        case iOS = "iOS"
+        case iOSSimulator = "iOS Simulator"
+        case tvOS = "tvOS"
+        case tvOSSimulator = "tvOS Simulator"
+        case watchOS = "watchOS"
+        case watchOSSimulator = "watchOS Simulator"
+        case macOS = "OS X"
+        
+        static var allSupported: [Self] {
+            return [
+                .iOS,
+                .watchOS,
+                .macOS,
+                .tvOS,
+            ]
+        }
     }
     
     public struct Name {
@@ -38,16 +47,22 @@ public struct Destination: Equatable {
         public static let iOS13_3 = "13.3"
     }
 
-    public init(
+    public init?(
         name: String = Name.iPhoneX,
-        platform: String = Platform.iOSSimulator,
+        platform: Platform = .iOSSimulator,
         os: String,
         udid: String? = nil
-    ) {
+    ) { 
         self.name = name
         self.platform = platform
         self.os = os
         self.udid = udid
+    }
+    
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+        return lhs.name == rhs.name &&
+               lhs.platform == rhs.platform &&
+               lhs.os == rhs.os
     }
 }
 


### PR DESCRIPTION
### Description

General refactoring and decomposition of the `GetDestinations` to prepare for unit tests

### Details

The initial idea was to just separate part related to CLI to complete unit tests for GetDestinations. However, there were some minor things that was possible to improve like making the logic more strict (using more enums!) or decomposing (parse, command protocol and struct). Subjectively, it's a bit more structured at the moment. Objectively it's possible to write unit tests with mocked environment. 