### PR TITLE
Correct spelling of xcodebuild testPlan flag

### DIFF
--- a/Sources/iOS/Library/Tools/XcodeBuild/Xcodebuild.swift
+++ b/Sources/iOS/Library/Tools/XcodeBuild/Xcodebuild.swift
@@ -77,7 +77,7 @@ public extension Xcodebuild {
 
     mutating func testPlan(_ path: String) {
         let path = path.deletingPathExtension("xctestplan")
-        arguments.append("-testplan \(path)")
+        arguments.append("-testPlan \(path)")
     }
 
     mutating func exportPath(_ path: String) {


### PR DESCRIPTION
`xcodebuild`'s test plan flag at some point changed from `-testplan` to `-testPlan`. This caused tasks configured to run test plans to fail.