### PR TITLE
Include XmlDict key in generated XML string

### DIFF
--- a/Sources/Core/Library/Xml/Xml.swift
+++ b/Sources/Core/Library/Xml/Xml.swift
@@ -57,6 +57,7 @@ public struct XmlDict: XmlItem {
 
     public func toLines() -> [String] {
         var lines = [String]()
+        lines.append("<key>\(key)</key>")
         lines.append("<dict>")
         lines.append(contentsOf: items.flatMap({ $0.toLines() }))
         lines.append("</dict>")


### PR DESCRIPTION
Adds an `XmlDict`'s key to the generated XML string. Previously, this caused `exportArchive` to produce an invalid `ExportOptions.plist` file.